### PR TITLE
TypeScript: Allow undefined second arg to `guessBest` to match `guess`

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -54,7 +54,7 @@ declare module '@horizon-rs/language-guesser' {
 
         private transformAllowList(allowList: string[]): string[];
         guess(utterance: string, allowList?: string[], limit?: number): GuessResult[];
-        guessBest(utterance: string, allowList: string[]): GuessResult;
+        guessBest(utterance: string, allowList?: string[]): GuessResult;
         addTrigrams(locale: string, sentence: string): void;
         addExtraSentence(locale: string, sentence: string): void;
         processExtraSentences(): void;


### PR DESCRIPTION
👋🏼 from GitHub Docs. I found this nit while updating some JS code to TS. I believe this was likely an oversight but let me know otherwise.

cc @MaximilianoVeiga 